### PR TITLE
#78 Add summary info to candidate contributions' endpoint

### DIFF
--- a/server/api_doc.md
+++ b/server/api_doc.md
@@ -211,7 +211,13 @@ response:
       "employer_name": "M. Reid Acree Jr. attorney at law"
     }
   ],
-  "count": "25059"
+  "count": "25059",
+  "summary": {
+    "sum": 7348500,
+    "avg": 293.247912627501,
+    "max": 158187,
+    "count": 25059
+  }
 }
 ```
 

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+/**
+ * @typedef {Object} CandidateSummary
+ * @property {Number} sum - The sum of all donations given to a candidate
+ * @property {Number} avg - The avg of all donation given to a candidate
+ * @property {Number} max - The largest donation given to a candidate
+ * @property {Number} count - The number of donations given to a candidate
+ */
+
+/**
+ *
+ * @param {string} ncsbeID
+ * @param {import('pg').PoolClient} client
+ * @returns {Promise<CandidateSummary>}
+ */
+const getCandidateSummary = async (ncsbeID, client) => {
+  const summary = await client.query(
+    `select sum(amount), avg(amount), max(amount), count(*)::int
+        from contributions
+        where committee_sboe_id = $1;`,
+    [ncsbeID]
+  )
+
+  return summary.rows.length > 0 ? summary.rows[0] : {}
+}
+
+module.exports = {
+  getCandidateSummary,
+}


### PR DESCRIPTION
#closes #78 

Adds summary info to the `/candidate/:ncsbeID/contributions` endpoint.

If we want to move or add this to the `/candidate/:ncsbeID` endpoint I'd be okay with that. I had a hard time deciding where this info should go. I decided on the contributions endpoint because that's the page that will display the info.