### PR TITLE
Fix messed up candidate_full_names

### DIFF
--- a/server/bin/etl.js
+++ b/server/bin/etl.js
@@ -37,13 +37,13 @@ const { copyFromCSV } = require('../db/copyFromCSV')
       'alter table committees add column candidate_first_last_name text'
     )
     await client.query(
-      `update committees set candidate_full_name = candidate_first_name || ' ' || candidate_middle_name || ' ' || candidate_last_name where candidate_middle_name is not NULL`
+      `update committees set candidate_full_name = CONCAT_WS(' ', candidate_first_name, candidate_middle_name, candidate_last_name) where candidate_middle_name is not NULL`
     )
     await client.query(
-      `update committees set candidate_full_name = candidate_first_name || ' ' || candidate_last_name where candidate_middle_name is NULL`
+      `update committees set candidate_full_name = CONCAT_WS(' ', candidate_first_name, candidate_last_name) where candidate_middle_name is NULL`
     )
     await client.query(
-      `update committees set candidate_first_last = candidate_first_name || ' ' || candidate_last_name`
+      `update committees set candidate_first_last_name = CONCAT_WS(' ', candidate_first_name, candidate_last_name)`
     )
   } catch (error) {
     console.error(error)

--- a/server/bin/etl.js
+++ b/server/bin/etl.js
@@ -37,10 +37,7 @@ const { copyFromCSV } = require('../db/copyFromCSV')
       'alter table committees add column candidate_first_last_name text'
     )
     await client.query(
-      `update committees set candidate_full_name = CONCAT_WS(' ', candidate_first_name, candidate_middle_name, candidate_last_name) where candidate_middle_name is not NULL`
-    )
-    await client.query(
-      `update committees set candidate_full_name = CONCAT_WS(' ', candidate_first_name, candidate_last_name) where candidate_middle_name is NULL`
+      `update committees set candidate_full_name = CONCAT_WS(' ', candidate_first_name, candidate_middle_name, candidate_last_name)`
     )
     await client.query(
       `update committees set candidate_first_last_name = CONCAT_WS(' ', candidate_first_name, candidate_last_name)`

--- a/server/bin/etl.js
+++ b/server/bin/etl.js
@@ -37,10 +37,13 @@ const { copyFromCSV } = require('../db/copyFromCSV')
       'alter table committees add column candidate_first_last_name text'
     )
     await client.query(
-      `update committees set candidate_full_name = candidate_first_name || ' ' || candidate_middle_name || ' ' || candidate_last_name`
+      `update committees set candidate_full_name = candidate_first_name || ' ' || candidate_middle_name || ' ' || candidate_last_name where candidate_middle_name is not NULL`
     )
     await client.query(
-      `update committees set candidate_first_last_name = candidate_first_name || ' ' || candidate_last_name`
+      `update committees set candidate_full_name = candidate_first_name || ' ' || candidate_last_name where candidate_middle_name is NULL`
+    )
+    await client.query(
+      `update committees set candidate_first_last = candidate_first_name || ' ' || candidate_last_name`
     )
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
closes #99

The ETL script wasn't accounting for blank middle names when adding the `candidate_full_name` column. I fixed that, so now it will work for candidates with and without middle names