### PR TITLE
Wait for db to be ready before running tests in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,13 +20,15 @@ jobs:
         id: cache
         uses: actions/cache@v2.1.0
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: cd server && npm install
       - name: Run dockerized db
         run: docker-compose -f docker-compose.yml up -d postgres-test
+      - name: Wait for db to be ready
+        run: ./scripts/wait-for-postgres.sh ${TEST_DATABASE_URL}
       - name: Run tests
         run: cd server && npm test
   deploy:
@@ -40,4 +42,4 @@ jobs:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          buildpack: 'https://github.com/heroku/heroku-buildpack-nodejs.git'
+          buildpack: "https://github.com/heroku/heroku-buildpack-nodejs.git"

--- a/scripts/wait-for-postgres.sh
+++ b/scripts/wait-for-postgres.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# wait-for-postgres.sh
+
+set -e
+
+dburl="$1"
+shift
+
+until psql "$dburl" -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up"

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -3,6 +3,7 @@ const { Pool } = require('pg')
 require('dotenv').config()
 
 const pool = new Pool({
+  connectionTimeoutMillis: 5000,
   connectionString:
     process.env.NODE_ENV === 'test'
       ? process.env.TEST_DATABASE_URL

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -3,7 +3,6 @@ const { Pool } = require('pg')
 require('dotenv').config()
 
 const pool = new Pool({
-  connectionTimeoutMillis: 5000,
   connectionString:
     process.env.NODE_ENV === 'test'
       ? process.env.TEST_DATABASE_URL


### PR DESCRIPTION
Tests were running before DB was accepting connection.

This adds a script and a step that calls the script to the build process to ensure DB is running and accepting connections before moving on to tests.