### PR TITLE
Bug Candidate quick search is returning blank results

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -281,11 +281,11 @@ api.get('/candidates/:year', async (req, res) => {
         select
           distinct on (committees.sboe_id)
           committees.*
-
         from committees
         inner join contributions
         on contributions.committee_sboe_id = committees.sboe_id
         where date_part('year', to_date(contributions.date_occurred, 'MM/DD/YY')) = $1
+        and candidate_full_name != '' -- Exclude non-candidate committees
       )
       select *, count(*) over () as full_count
       from candidates_for_year


### PR DESCRIPTION
## Bug

Since the committees table contains data for candidates and committees, the quick search endpoint is returning data with blank `candidate_full_name` fields.

## Solution

Ensure the candidate_full_name column is not blank when querying for candidates

Bug Example:
![Screenshot_2020-09-11 NC Campaign Finance Dashboard](https://user-images.githubusercontent.com/9397068/92973844-78e6d980-f474-11ea-93e0-0cc6c995fee3.png)
