### PR TITLE
enforce ssl in production

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,10 +1,32 @@
+//@ts-check
 const express = require('express')
 const path = require('path')
 const bodyParser = require('body-parser')
 
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+const enforceSSL = (req, res, next) => {
+  console.log(req)
+  if (req.protocol === 'http') {
+    res.redirect(301, 'https://' + req.hostname + req.url)
+    return
+  }
+  next()
+}
+
 const api = require('./api')
 
 const app = express()
+
+// Register this before all other handlers if we are in prod
+if (process.env.NODE_ENV === 'production') {
+  app.use(enforceSSL)
+}
+
 app.use(bodyParser.json())
 app.use('/api', api)
 app.get('/status', (req, res) => res.send({ status: 'online' }))


### PR DESCRIPTION
Automatically redirect all requests to `https` if NODE_ENV is in production. I'm limited in how I can test this locally, so I will watch the deploy carefully and make sure it works