### PR TITLE
Removed links from footer and hid contributors quick search.

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -7,7 +7,7 @@ import {
   Logo,
 } from '@trussworks/react-uswds'
 
-import { PRIVACY_POLICY_ROUTE } from '../constants'
+// import { PRIVACY_POLICY_ROUTE } from '../constants'
 
 const Footer = () => {
   return (
@@ -18,18 +18,17 @@ const Footer = () => {
             <div className="footer-nav">
               <FooterNav
                 links={[
-                  <a className="usa-footer__primary-link" href="/">
-                    Terms of Use
-                  </a>,
-                  <a className="usa-footer__primary-link" href="/">
-                    Sitemap
-                  </a>,
-                  <a
-                    className="usa-footer__primary-link"
-                    href={PRIVACY_POLICY_ROUTE}
-                  >
-                    Privacy Policy
-                  </a>,
+                  // HIDING TERMS OF USE AND PRIVACY POLICY UNTIL WE CONFIRM WE DON'T NEED THEM
+
+                  // <a className="usa-footer__primary-link" href="/">
+                  //   Terms of Use
+                  // </a>,
+                  // <a
+                  //   className="usa-footer__primary-link"
+                  //   href={PRIVACY_POLICY_ROUTE}
+                  // >
+                  //   Privacy Policy
+                  // </a>,
                   <a
                     className="usa-footer__primary-link"
                     href="https://forms.gle/5c4dmuTPVCznSB1s8"

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -61,14 +61,15 @@ const SearchBar = ({ hideQuickLinks }) => {
           >
             {`${ELECTION_YEAR} Candidates`}
           </Button>
-          <Button
+          {/* Hiding until we're ready to deploy individual contributor pages */}
+          {/* <Button
             outline
             type="button"
             className="search-btn"
             onClick={handleQuickDonorLink}
           >
             {`${ELECTION_YEAR} Contributors`}
-          </Button>
+          </Button> */}
         </div>
       )}
     </div>


### PR DESCRIPTION
Hid links we aren't using for now. Will remove them if we don't need them by the time we are ready to launch our next round of features. Hid Contributors quick search button until we have those tables ready. 