### PR TITLE
[90] Candidate sorting and filtering

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -114,7 +114,7 @@ api.get('/search/contributors/:name', async (req, res) => {
 api.get('/search/candidates/:name', async (req, res) => {
   try {
     const { name } = req.params
-    const { offset = 0, limit = 50, sort = 'first_last_sml' } = req.query
+    const { offset = 0, limit = 50, sortBy = 'first_last_sml' } = req.query
     const decodedName = decodeURIComponent(name)
 
     const committees = await searchCommittees(
@@ -122,7 +122,7 @@ api.get('/search/candidates/:name', async (req, res) => {
       offset,
       limit,
       TRIGRAM_LIMIT,
-      sort
+      sortBy
     )
     return res.send({
       data: committees.data.map(apiReprCandidate),

--- a/server/api.js
+++ b/server/api.js
@@ -124,7 +124,14 @@ api.get('/search/contributors/:name', async (req, res) => {
 api.get('/search/candidates/:name', async (req, res) => {
   try {
     const { name } = req.params
-    const { offset = 0, limit = 50, sortBy = 'first_last_sml' } = req.query
+    const {
+      offset = 0,
+      limit = 50,
+      sortBy = 'first_last_sml',
+      name: nameFilter,
+      party,
+      contest,
+    } = req.query
     const decodedName = decodeURIComponent(name)
 
     const committees = await searchCommittees(
@@ -132,7 +139,10 @@ api.get('/search/candidates/:name', async (req, res) => {
       offset,
       limit,
       TRIGRAM_LIMIT,
-      sortBy
+      sortBy,
+      nameFilter,
+      party,
+      contest
     )
     return res.send({
       data: committees.data.map(apiReprCandidate),

--- a/server/api.js
+++ b/server/api.js
@@ -114,14 +114,15 @@ api.get('/search/contributors/:name', async (req, res) => {
 api.get('/search/candidates/:name', async (req, res) => {
   try {
     const { name } = req.params
-    const { offset = 0, limit = 50 } = req.query
+    const { offset = 0, limit = 50, sort = 'first_last_sml' } = req.query
     const decodedName = decodeURIComponent(name)
 
     const committees = await searchCommittees(
       decodedName,
       offset,
       limit,
-      TRIGRAM_LIMIT
+      TRIGRAM_LIMIT,
+      sort
     )
     return res.send({
       data: committees.data.map(apiReprCandidate),

--- a/server/api_doc.md
+++ b/server/api_doc.md
@@ -50,6 +50,10 @@ Query Params (optional):
 
 - `offset` default value `0`
 - `limit` default value `50`
+- `sortBy` default value `first_last_sml`
+- `name`
+- `party`
+- `contest`
 
 Example: `/api/search/candidates/roy%20cooper?limit=1&offset=0`
 response:

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -62,6 +62,9 @@ const searchContributors = async (
  * @param {string|number} limit
  * @param {string|number} trigramLimit
  * @param {string} sort
+ * @param {string} nameFilter
+ * @param {string} partyFilter
+ * @param {string} contestFilter
  * @returns {Promise<SearchResult>}
  * @throws an error if the pg query or connection fails
  */
@@ -95,16 +98,12 @@ const searchCommittees = async (
           (candidate_full_name % $1
           OR candidate_last_name % $1
           OR candidate_full_name ilike $4)
-          ${partyFilter ? `AND party ilike \'%${partyFilter}%\'` : ''}
-          ${
-            nameFilter
-              ? `AND candidate_full_name ilike \'%${nameFilter}%\'`
-              : ''
-          }
+          ${partyFilter ? `AND party ilike '%${partyFilter}%'` : ''}
+          ${nameFilter ? `AND candidate_full_name ilike '%${nameFilter}%'` : ''}
           ${
             contestFilter
-              ? `AND (juris ilike \'%${contestFilter}%\'
-              OR office ilike \'%${contestFilter}%\')`
+              ? `AND (juris ilike '%${contestFilter}%'
+              OR office ilike '%${contestFilter}%')`
               : ''
           }
         order by ${order}

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -96,6 +96,17 @@ const searchCommittees = async (
           OR candidate_last_name % $1
           OR candidate_full_name ilike $4)
           ${partyFilter ? `AND party ilike \'%${partyFilter}%\'` : ''}
+          ${
+            nameFilter
+              ? `AND candidate_full_name ilike \'%${nameFilter}%\'`
+              : ''
+          }
+          ${
+            contestFilter
+              ? `AND (juris ilike \'%${contestFilter}%\'
+              OR office ilike \'%${contestFilter}%\')`
+              : ''
+          }
         order by ${order}
         limit $2 offset $3`,
       [name, limit, offset, nameILike]

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -57,9 +57,11 @@ const searchCommittees = async (
   name,
   offset = 0,
   limit = 50,
-  trigramLimit = 0.6
+  trigramLimit = 0.6,
+  sort = 'first_last_sml'
 ) => {
   let client = null
+  const order = sort.startsWith('-') ? `${sort} DESC` : sort
   try {
     client = await getClient()
     await client.query('select set_limit($1)', [trigramLimit])
@@ -72,9 +74,9 @@ const searchCommittees = async (
       from committees
         where
           candidate_full_name % $1 OR candidate_last_name % $1
-        order by first_last_sml
+        order by $4
         limit $2 offset $3`,
-      [name, limit, offset]
+      [name, limit, offset, order]
     )
 
     return {

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -61,7 +61,10 @@ const searchCommittees = async (
   sort = 'first_last_sml'
 ) => {
   let client = null
-  const order = sort.startsWith('-') ? `${sort} DESC` : sort
+  let order = ['first_last_sml', '-first_last_sml'].includes(sort)
+    ? sort
+    : 'first_last_sml'
+  order = order.startsWith('-') ? `${sort} DESC` : sort
   try {
     client = await getClient()
     await client.query('select set_limit($1)', [trigramLimit])

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1869,6 +1869,11 @@
         "obuf": "^1.1.2"
       }
     },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4="
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "node-pg-migrate": "^5.3.0",
     "pg": "^8.3.0",
     "pg-copy-streams": "^5.1.1",
+    "pg-format": "^1.0.4",
     "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- Allow sorting of candidate results by `name` and `first_last_sml` (both `ASC` or `DESC`)
- Allow filtering of candidate results by `name`
- Allow filtering of candidate results by `contest`
- Allow filtering of candidate results by `party`
- update apidoc

Fixes #90 