### PR TITLE
[93] Candidate Contributors sorting and filtering

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -177,7 +177,18 @@ api.get('/candidate/:ncsbeID/contributions', async (req, res) => {
   let client = null
   try {
     let { ncsbeID = '' } = req.params
-    const { limit = 50, offset = 0, toCSV = false, sortBy } = req.query
+    const {
+      limit = 50,
+      offset = 0,
+      toCSV = false,
+      sortBy,
+      name,
+      transaction_type,
+      amount,
+      form_of_payment,
+      date_occurred_gte,
+      date_occurred_lte,
+    } = req.query
     ncsbeID = decodeURIComponent(ncsbeID)
     if (!ncsbeID) {
       res.status(500)
@@ -194,6 +205,12 @@ api.get('/candidate/:ncsbeID/contributions', async (req, res) => {
         offset,
         client,
         sortBy,
+        name,
+        transaction_type,
+        amount,
+        form_of_payment,
+        date_occurred_gte,
+        date_occurred_lte,
       })
 
       const summaryPromise = getCandidateSummary(ncsbeID, client)

--- a/server/api.js
+++ b/server/api.js
@@ -177,7 +177,7 @@ api.get('/candidate/:ncsbeID/contributions', async (req, res) => {
   let client = null
   try {
     let { ncsbeID = '' } = req.params
-    const { limit = 50, offset = 0, toCSV = false } = req.query
+    const { limit = 50, offset = 0, toCSV = false, sortBy } = req.query
     ncsbeID = decodeURIComponent(ncsbeID)
     if (!ncsbeID) {
       res.status(500)
@@ -193,6 +193,7 @@ api.get('/candidate/:ncsbeID/contributions', async (req, res) => {
         limit,
         offset,
         client,
+        sortBy,
       })
 
       const summaryPromise = getCandidateSummary(ncsbeID, client)

--- a/server/api_doc.md
+++ b/server/api_doc.md
@@ -113,6 +113,13 @@ Query Params (optional):
 - `offset` default value `0`
 - `limit` default value `50`
 - `toCSV` default value `false`
+- `sortBy` sort by `name`, `amount` or `date_occurred`. Prefix with `-` for `DESC` order
+- `name` fuzzy match results on contributor name
+- `transaction_type` exact match
+- `amount` exact match
+- `form_of_payment` exact match
+- `date_occurred_gte` match results with `date_occurred` greater than and equal to the provided date (`1/1/2020`)
+- `date_occurred_lte` match results with `date_occurred` greater than and equal to the provided date (`1/1/2020`)
 
 Example: `/api/candidate/STA-C0498N-C-002/contributions?limit=2`
 response:

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1,4 +1,5 @@
 // @ts-check
+const format = require('pg-format')
 
 const SUPPORTED_CANDIDATE_CONTRIBUTION_SORT_FIELDS = [
   'name',
@@ -70,12 +71,12 @@ const getCandidateContributions = ({
   offset = 0,
   client,
   sortBy = null,
-  name = null,
-  transaction_type = null,
-  amount = null,
-  form_of_payment = null,
-  date_occurred_gte = null,
-  date_occurred_lte = null,
+  name: nameFilter = null,
+  transaction_type: transaction_typeFilter = null,
+  amount: amountFilter = null,
+  form_of_payment: form_of_paymentFilter = null,
+  date_occurred_gte: date_occurred_gteFilter = null,
+  date_occurred_lte: date_occurred_lteFilter = null,
 }) => {
   let order = SUPPORTED_CANDIDATE_CONTRIBUTION_SORT_FIELDS.includes(sortBy)
     ? sortBy
@@ -84,7 +85,37 @@ const getCandidateContributions = ({
   order = order.startsWith('-')
     ? `${order.replace('-', '')} DESC`
     : `${order} ASC`
-  console.log('date_occurred_gte', date_occurred_gte)
+
+  const safeNameFilter = nameFilter
+    ? format('AND upper(name) ilike %s', `'%${nameFilter.toUpperCase()}%'`)
+    : ''
+  const safeTransactionTypeFilter = transaction_typeFilter
+    ? format(
+        'AND upper(transaction_type) = %L',
+        transaction_typeFilter.toUpperCase()
+      )
+    : ''
+  const safeAmountFilter = amountFilter
+    ? format('AND amount = %L', amountFilter)
+    : ''
+  const safeFormOfPaymentFilter = form_of_paymentFilter
+    ? format(
+        'AND upper(form_of_payment) = %L',
+        form_of_paymentFilter.toUpperCase()
+      )
+    : ''
+  const safeDateOccurredGteFilter = date_occurred_gteFilter
+    ? format(
+        'AND CAST(date_occurred as DATE) >= CAST(%L as DATE)',
+        date_occurred_gteFilter
+      )
+    : ''
+  const safeDateOccurredLteFilter = date_occurred_lteFilter
+    ? format(
+        'AND CAST(date_occurred as DATE) <= CAST(%L as DATE)',
+        date_occurred_lteFilter
+      )
+    : ''
 
   return client.query(
     `select count(*) over () as full_count,
@@ -111,28 +142,12 @@ const getCandidateContributions = ({
               join contributors c on contributions.contributor_id = c.id
       where (
         lower(contributions.committee_sboe_id) = lower($1)
-        ${name ? `AND upper(name) ilike '%${name.toUpperCase()}%'` : ''}
-        ${
-          transaction_type
-            ? `AND upper(transaction_type) ='${transaction_type.toUpperCase()}'`
-            : ''
-        }
-        ${amount ? `AND amount ='${amount}'` : ''}
-        ${
-          form_of_payment
-            ? `AND upper(form_of_payment) ='${form_of_payment.toUpperCase()}'`
-            : ''
-        }
-        ${
-          date_occurred_gte
-            ? `AND CAST(date_occurred as DATE) >= CAST('${date_occurred_gte}' as DATE)`
-            : ''
-        }
-        ${
-          date_occurred_lte
-            ? `AND CAST(date_occurred as DATE) <= CAST('${date_occurred_lte}' as DATE)`
-            : ''
-        }
+        ${safeNameFilter}
+        ${safeTransactionTypeFilter}
+        ${safeAmountFilter}
+        ${safeFormOfPaymentFilter}
+        ${safeDateOccurredGteFilter}
+        ${safeDateOccurredLteFilter}
       )
       ${sortBy ? `order by ${order}` : ''}
       limit $2

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -68,6 +68,7 @@ const getCandidateContributions = ({
   let order = SUPPORTED_CANDIDATE_CONTRIBUTION_SORT_FIELDS.includes(sortBy)
     ? sortBy
     : ''
+  order = order.replace('date_occurred', 'CAST(date_occurred as DATE)')
   order = order.startsWith('-')
     ? `${order.replace('-', '')} DESC`
     : `${order} ASC`


### PR DESCRIPTION
- Allow sorting of candidate contributor results by `name`, `amount` or `date_occurred`
- Allow filtering of candidate contributor results by `name` (fuzzy match)
- Allow filtering of candidate contributor results by `transaction_type` (exact match)
- Allow filtering of candidate contributor results by `amount` (exact match)
- Allow filtering of candidate contributor results by `form_of_payment` (exact match)
- Allow filtering of candidate contributor results by `date_occurred_gte` (greater than equal date filter)
- Allow filtering of candidate contributor results by `date_occurred_lte` (less than equal date filter)
- Update apidoc

Fixes #93 