### PR TITLE
Add GET /api/contributor/:contributorId

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -318,6 +318,32 @@ api.get('/contributors/:contributorId/contributions', async (req, res) => {
   }
 })
 
+api.get('/contributor/:contributorId', async (req, res) => {
+  let client = null
+  try {
+    const { contributorId } = req.params
+    client = await getClient()
+    const result = await client.query(
+      `select * from contributors where id = $1`,
+      [contributorId]
+    )
+    const contributor =
+      result.rows.length > 0 ? apiReprContributor(result.rows[0]) : null
+
+    // Return 404 and data = null if the contributor was not found
+    res.status(contributor === null ? 404 : 200)
+    return res.send({
+      data: contributor,
+    })
+  } catch (error) {
+    handleError(error, res)
+  } finally {
+    if (client !== null) {
+      client.release()
+    }
+  }
+})
+
 api.get('/candidates/:year', async (req, res) => {
   let client = null
   try {

--- a/server/api_doc.md
+++ b/server/api_doc.md
@@ -236,6 +236,42 @@ response:
 }
 ```
 
+## GET `/api/contributor/:contributorId`
+
+Get an individual contributor by ID
+
+Example: `/api/contributor/8ce7bc9f-2c13-45ac-8395-3e46b4191490`
+
+response:
+
+status code: 200
+
+```json
+{
+  "data": {
+    "contributor_id": "8ce7bc9f-2c13-45ac-8395-3e46b4191490",
+    "name": "John D. Smith II",
+    "city": "Eden",
+    "state": "NC",
+    "zip_code": "27289-0590",
+    "profession": "Property Management",
+    "employer_name": "Self"
+  }
+}
+```
+
+If the contributor id is not found, the `data` field will be `null` and the response code will be `404`
+
+Example: `/api/contributor/00000000-0000-0000-0000-000000000000`
+
+status code: 404
+
+```json
+{
+  "data": null
+}
+```
+
 ## GET `/api/contributors/:year
 
 Retrieve all contributors for a given year.

--- a/server/test/test-routes.js
+++ b/server/test/test-routes.js
@@ -266,6 +266,36 @@ describe('GET /api/contributors/:contributorId/contributions', function () {
   })
 })
 
+describe('GET /api/contributor/:contributorId', function () {
+  it('it should have status 200 and correct schema', async function () {
+    const client = await getClient()
+    const { rows } = await client.query(
+      'select id FROM contributors limit 1',
+      []
+    )
+    client.release()
+    const id = encodeURIComponent(rows[0].id)
+    const response = await supertest(app).get(`/api/contributor/${id}`)
+    response.status.should.equal(200)
+    response.body.should.be.an('object').that.has.all.keys(['data'])
+    response.body.data.should.be
+      .an('object')
+      .that.has.all.keys(expectedContributorKeys)
+    Object.keys(response.body.data).length.should.equal(
+      expectedContributorKeys.length
+    )
+  })
+  it('it should have status 404 and data=null when contributor id is not found', async function () {
+    const client = await getClient()
+    client.release()
+    const id = encodeURIComponent('00000000-0000-0000-0000-000000000000')
+    const response = await supertest(app).get(`/api/contributor/${id}`)
+    response.status.should.equal(404)
+    response.body.should.be.an('object').that.has.all.keys(['data'])
+    chai.should().equal(response.body.data, null)
+  })
+})
+
 describe('GET /api/candidates/:year', function () {
   it('it should have status 200 and correct schema', async function () {
     const client = await getClient()


### PR DESCRIPTION
Closes #174 

Added a GET `api/contributor/:contributorId` route which returns information for an individual contributor. If the id is not found, a 404 is returned and the body has a data field with a null value (see API doc for example).