### PR TITLE
Fix Docker Startup Failing on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ first-run-windows: install clean-db-windows
 
 first-run-windows-no-docker: install migrate-up-windows etl
 
+wait-for-postgres:
+	echo "waiting for postgres"
+	$(shell ./scripts/wait-for-postgres.sh)
+
 install:
 	npm install
 	cd server && npm install
@@ -35,9 +39,9 @@ refresh-docker:
 	docker-compose -f docker-compose.yml down -v
 	docker-compose -f docker-compose.yml up -d
 
-clean-db: refresh-docker migrate-up etl
+clean-db: refresh-docker wait-for-postgres migrate-up etl
 
-clean-db-windows: refresh-docker migrate-up-windows etl
+clean-db-windows: refresh-docker wait-for-postgres migrate-up-windows etl
 
 etl:
 	cd server && node bin/etl.js

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ first-run-windows: install clean-db-windows
 
 first-run-windows-no-docker: install migrate-up-windows etl
 
+.PHONY: wait-for-postgres
 wait-for-postgres:
-	echo "waiting for postgres"
-	$(shell ./scripts/wait-for-postgres.sh)
+	./scripts/wait-for-postgres-local.sh
 
 install:
 	npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     container_name: campaign-finance-dashboard-db
     image: postgres
-    restart: always
+    restart: on-failure 
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
@@ -13,6 +13,7 @@ services:
   pgweb:
     container_name: campaign-finance-dashboard-pgweb
     image: sosedoff/pgweb
+    restart: on-failure 
     ports:
       - '8081:8081'
     links:
@@ -25,7 +26,7 @@ services:
   postgres-test:
     container_name: campaign-finance-dashboard-test-db
     image: postgres
-    restart: always
+    restart: on-failure
     environment:
       POSTGRES_DB: campaign-finance-test
       POSTGRES_PASSWORD: postgres

--- a/scripts/wait-for-postgres-local.sh
+++ b/scripts/wait-for-postgres-local.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# wait-for-postgres-local.sh
+
+dburl="$1"
+shift
+
+# If DBURL does not exist, default to the .env
+if [ -z $dburl ];
+  then
+    eval $(egrep -v '^#' server/.env | xargs)
+    dburl=$DATABASE_URL
+fi
+
+until psql "$dburl" -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up"

--- a/scripts/wait-for-postgres.sh
+++ b/scripts/wait-for-postgres.sh
@@ -6,13 +6,6 @@ set -e
 dburl="$1"
 shift
 
-# If DBURL does not exist, default to the .env
-if [ -z $dburl ];
-  then
-    eval $(egrep -v '^#' server/.env | xargs)
-    dburl=$DATABASE_URL
-fi
-
 until psql "$dburl" -c '\q'; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1

--- a/scripts/wait-for-postgres.sh
+++ b/scripts/wait-for-postgres.sh
@@ -6,6 +6,13 @@ set -e
 dburl="$1"
 shift
 
+# If DBURL does not exist, default to the .env
+if [ -z $dburl ];
+  then
+    eval $(egrep -v '^#' server/.env | xargs)
+    dburl=$DATABASE_URL
+fi
+
 until psql "$dburl" -c '\q'; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1


### PR DESCRIPTION
Docker startup sometimes fails on Mac. The issue appears to be that `make refresh-docker` exists before the database container is ready to accept connections. To fix this I modified the `wait-for-postgres.sh` script to read from the `.env` file if no URL is provided as an argument. I then added a `wait-for-postgres` step to the Makefile which is run after calling `refresh-docker`

I also change the restart policy of the containers in the docker-compose file to `on-failure` this should prevent the containers from automatically restarting when you restart your computer. (This was bugging me)