### PR TITLE
[210] Remove 'back to search results' link. Fix other errors and warnings

### DIFF
--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useState } from 'react'
-import { useParams, useLocation, Link } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { Grid, GridContainer } from '@trussworks/react-uswds'
 import NumberFormat from 'react-number-format'
 
@@ -13,7 +13,6 @@ import ReportError from './ReportError'
 
 const Candidate = () => {
   let { candidateId } = useParams()
-  const location = useLocation()
   const [lastQuery, setLastQuery] = useState({})
 
   const {
@@ -88,13 +87,6 @@ const Candidate = () => {
   return (
     <div className="container">
       <GridContainer>
-        <Grid row>
-          <Grid col>
-            {location?.fromPathname ? (
-              <Link to={location.fromPathname}>Back to search results</Link>
-            ) : null}
-          </Grid>
-        </Grid>
         <Grid row>
           <Grid col>
             <p className="candidate-label">CANDIDATE</p>

--- a/src/components/Contributor.js
+++ b/src/components/Contributor.js
@@ -17,7 +17,6 @@ const Contributor = () => {
     contributor,
     apiStatus,
     contributions,
-    summary,
     contributionCount,
     contributionOffset,
     fetchInitialSearchData,

--- a/src/components/Contributor.js
+++ b/src/components/Contributor.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react'
-import { useParams, useLocation, Link } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { Grid, GridContainer } from '@trussworks/react-uswds'
 
 import { useContributors } from '../hooks/useContributors'
@@ -12,7 +12,6 @@ import '../css/candidate.scss'
 
 const Contributor = () => {
   let { contributorId } = useParams()
-  const location = useLocation()
 
   const {
     contributor,
@@ -70,13 +69,6 @@ const Contributor = () => {
   return (
     <div className="container">
       <GridContainer>
-        <Grid row>
-          <Grid col>
-            {location?.fromPathname ? (
-              <Link to={location.fromPathname}>Back to search results</Link>
-            ) : null}
-          </Grid>
-        </Grid>
         <Grid row>
           <Grid col>
             <p className="contributor-label">CONTRIBUTOR</p>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,14 +3,13 @@ import {
   Header as HeaderComponent,
   NavMenuButton,
   PrimaryNav,
-  Title,
 } from '@trussworks/react-uswds'
 
 import { DEFAULT_ROUTE, DATA_DICTIONARY_ROUTE, ABOUT_ROUTE } from '../constants'
 
 const Header = () => {
   const [expanded, setExpanded] = useState(false)
-  const onClick = (): void => setExpanded((prvExpanded) => !prvExpanded)
+  const onClick = () => setExpanded((prvExpanded) => !prvExpanded)
 
   const menuItems = [
     <a key="search" className="usa-nav__link" href={DEFAULT_ROUTE}>

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -153,9 +153,11 @@ export default function Table({
       </thead>
       <tbody {...getTableBodyProps()}>
         {isLoading ? (
-          <td colspan={columns.length}>
-            <Spinner />
-          </td>
+          <tr>
+            <td colSpan={columns.length}>
+              <Spinner />
+            </td>
+          </tr>
         ) : (
           <>
             {rows.map((row, i) => {

--- a/src/hooks/useTableColumns.js
+++ b/src/hooks/useTableColumns.js
@@ -108,13 +108,8 @@ export const useTableColumns = () => {
         Header: 'Name',
         id: 'candidate_full_name',
         accessor: ({ candidate_full_name, committee_sboe_id }) => (
-          <Link
-            to={(location) => ({
-              pathname: CANDIDATE_URL + committee_sboe_id,
-              fromPathname: location.pathname,
-            })}
-          >
-            {' '}
+          <Link to={`${CANDIDATE_URL}${committee_sboe_id}`}>
+            &nbsp;
             {candidate_full_name}
           </Link>
         ),
@@ -140,15 +135,7 @@ export const useTableColumns = () => {
         Header: 'Contributor Name',
         id: 'name',
         accessor: ({ contributor_id, name }) => (
-          <Link
-            to={(location) => ({
-              pathname: CONTRIBUTOR_URL + contributor_id,
-              fromPathname: location.pathname,
-            })}
-          >
-            {' '}
-            {name}
-          </Link>
+          <Link to={`${CONTRIBUTOR_URL}${contributor_id}`}>&nbsp;{name}</Link>
         ),
       },
       {


### PR DESCRIPTION
- Remove `back to search results` link
- Remove `fromPathname` route param
- Fix console errors related to Table spinner
- Fix TS compilation errors

Fixes #210 

Candidate Page
<img width="999" alt="Screen Shot 2021-02-26 at 2 44 40 PM" src="https://user-images.githubusercontent.com/39271238/109348022-fe532000-7841-11eb-9121-d31fda55d194.png">

Contribution Page
<img width="1000" alt="Screen Shot 2021-02-26 at 2 44 33 PM" src="https://user-images.githubusercontent.com/39271238/109348038-0317d400-7842-11eb-8cfa-9ca680686982.png">
