### PR TITLE
Add filtering to tables on Search Results page

### DIFF
--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -38,12 +38,12 @@ const Candidate = () => {
     }
   }, [candidateId, fetchInitialSearchData])
 
-  const handleSortChange = useCallback(
-    (sortBy) => {
+  const handleDataFetch = useCallback(
+    ({ sortBy, filters }) => {
       // we don't support multisort, so get the first element in the sortBy array if it exists
       const sort = formatSortBy(sortBy)
-      if (sort !== lastQuery.sort) {
-        const query = { ...lastQuery, sort }
+      if (sort !== lastQuery.sort || filters !== lastQuery.filters) {
+        const query = { ...lastQuery, sort, filters }
         setLastQuery(query)
         fetchContributions(query)
       }
@@ -201,7 +201,7 @@ const Candidate = () => {
               fetchPrevious={fetchPreviousContributions}
               searchTerm={candidateId}
               searchType="contributions"
-              onChangeSort={handleSortChange}
+              onFetchData={handleDataFetch}
               initialSortBy={[{ id: 'date_occurred', desc: true }]}
             />
           </Grid>

--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -39,11 +39,11 @@ const Candidate = () => {
   }, [candidateId, fetchInitialSearchData])
 
   const handleDataFetch = useCallback(
-    ({ sortBy, filters }) => {
+    ({ sortBy }) => {
       // we don't support multisort, so get the first element in the sortBy array if it exists
       const sort = formatSortBy(sortBy)
-      if (sort !== lastQuery.sort || filters !== lastQuery.filters) {
-        const query = { ...lastQuery, sort, filters }
+      if (sort !== lastQuery.sort) {
+        const query = { ...lastQuery, sort }
         setLastQuery(query)
         fetchContributions(query)
       }

--- a/src/components/InputFilter.js
+++ b/src/components/InputFilter.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const InputFilter = ({ column: { setFilter, filterValue, Header } }) => (
+  <input
+    value={filterValue || ''}
+    placeholder={`Filter by ${Header.toLowerCase()}`}
+    onChange={(e) => {
+      setFilter(e.target.value)
+    }}
+  />
+)
+
+export default InputFilter

--- a/src/components/SearchResultTable.js
+++ b/src/components/SearchResultTable.js
@@ -23,7 +23,7 @@ const SearchResultTable = ({
   fetchPrevious,
   searchTerm,
   searchType,
-  onChangeSort,
+  onFetchData,
   initialSortBy,
 }) => {
   const { tableLimits } = useTablePagination()
@@ -64,7 +64,7 @@ const SearchResultTable = ({
         <Table
           columns={columns}
           data={data}
-          onChangeSort={onChangeSort}
+          onFetchData={onFetchData}
           initialSortBy={initialSortBy}
           isLoading={apiStatus === STATUSES.Pending}
         />

--- a/src/components/SearchResultTable.js
+++ b/src/components/SearchResultTable.js
@@ -12,90 +12,97 @@ const ResultsTableFooter = styled.div`
   display: flex;
   justify-content: space-between;
 `
-const SearchResultTable = ({
-  apiStatus,
-  columns,
-  data,
-  count,
-  offset,
-  fetchSame,
-  fetchNext,
-  fetchPrevious,
-  searchTerm,
-  searchType,
-  onFetchData,
-  initialSortBy,
-}) => {
-  const { tableLimits } = useTablePagination()
+const SearchResultTable = React.memo(
+  ({
+    apiStatus,
+    columns,
+    data,
+    count,
+    offset,
+    fetchSame,
+    fetchNext,
+    fetchPrevious,
+    searchTerm,
+    searchType,
+    onFetchData,
+    initialSortBy,
+    appliedFilters,
+  }) => {
+    const { tableLimits } = useTablePagination()
 
-  const [apiLimit, setApiLimit] = useState(10)
+    const [apiLimit, setApiLimit] = useState(10)
 
-  const onChangeLimit = useCallback(
-    (value) => {
-      setApiLimit(value)
-      fetchSame(value)
-    },
-    [fetchSame]
-  )
-
-  if (apiStatus === STATUSES.Unsent) {
-    return <Spinner />
-  } else if (apiStatus === STATUSES.Fail) {
-    return (
-      <Alert slim type="error">
-        Error fetching search data
-      </Alert>
+    const onChangeLimit = useCallback(
+      (value) => {
+        setApiLimit(value)
+        fetchSame(value)
+      },
+      [fetchSame]
     )
-  } else if (apiStatus === STATUSES.Success && count === 0) {
-    return <p>{`No ${searchType} found for "${searchTerm}"`}</p>
-  } else {
-    return (
-      <>
-        <Dropdown
-          value={apiLimit}
-          onChange={(e) => onChangeLimit(e.currentTarget.value)}
-        >
-          {tableLimits.map(({ label, value }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </Dropdown>
-        <Table
-          columns={columns}
-          data={data}
-          onFetchData={onFetchData}
-          initialSortBy={initialSortBy}
-          isLoading={apiStatus === STATUSES.Pending}
-        />
-        <ResultsTableFooter>
-          {`${offset + 1} - ${Math.min(
-            offset + apiLimit,
-            count
-          )} ${searchType} shown`}
-          <div>
-            <Button
-              onClick={() => fetchPrevious(apiLimit)}
-              size="small"
-              outline
-              disabled={offset === 0}
-            >
-              Previous
-            </Button>
-            <Button
-              onClick={() => fetchNext(apiLimit)}
-              style={{ marginRight: '0px' }}
-              size="small"
-              outline
-              disabled={offset + apiLimit >= count}
-            >
-              Next
-            </Button>
-          </div>
-        </ResultsTableFooter>
-      </>
-    )
+
+    if (apiStatus === STATUSES.Unsent) {
+      return <Spinner />
+    } else if (apiStatus === STATUSES.Fail) {
+      return (
+        <Alert slim type="error">
+          Error fetching search data
+        </Alert>
+      )
+    } else if (
+      apiStatus === STATUSES.Success &&
+      count === 0 &&
+      (appliedFilters ? appliedFilters.length === 0 : true)
+    ) {
+      return <p>{`No ${searchType} found for "${searchTerm}"`}</p>
+    } else {
+      return (
+        <>
+          <Dropdown
+            value={apiLimit}
+            onChange={(e) => onChangeLimit(e.currentTarget.value)}
+          >
+            {tableLimits.map(({ label, value }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Dropdown>
+          <Table
+            columns={columns}
+            data={data}
+            onFetchData={onFetchData}
+            initialSortBy={initialSortBy}
+            isLoading={apiStatus === STATUSES.Pending}
+          />
+          <ResultsTableFooter>
+            {`${count ? offset + 1 : count} - ${Math.min(
+              offset + apiLimit,
+              count
+            )} ${searchType} shown`}
+            <div>
+              <Button
+                onClick={() => fetchPrevious(apiLimit)}
+                size="small"
+                outline
+                disabled={offset === 0}
+              >
+                Previous
+              </Button>
+              <Button
+                onClick={() => fetchNext(apiLimit)}
+                style={{ marginRight: '0px' }}
+                size="small"
+                outline
+                disabled={offset + apiLimit >= count}
+              >
+                Next
+              </Button>
+            </div>
+          </ResultsTableFooter>
+        </>
+      )
+    }
   }
-}
+)
 
 export default SearchResultTable

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -218,7 +218,7 @@ const SearchResults = React.memo(() => {
   )
 
   return (
-    <GridContainer>
+    <GridContainer className="extra-width">
       <SearchBarContainer>
         <SearchBar hideQuickLinks />
       </SearchBarContainer>

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -166,7 +166,7 @@ const SearchResults = React.memo(() => {
             searchTerm={searchTerm}
             searchType="candidates"
             onFetchData={handleCandidateDataChange}
-            appliedFilters={lastCandidatesQuery.appliedFilters}
+            appliedFilters={lastCandidatesQuery.filters}
           />
         ),
         expanded: true,
@@ -187,7 +187,7 @@ const SearchResults = React.memo(() => {
             searchTerm={searchTerm}
             searchType="contributors"
             onFetchData={handleContributorDataChange}
-            appliedFilters={lastContributorsQuery.appliedFilters}
+            appliedFilters={lastContributorsQuery.filters}
           />
         ),
         expanded: true,

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -30,7 +30,7 @@ const SearchResults = React.memo(() => {
     fetchInitialSearchData,
   } = useSearch()
 
-  const { contributorColumns, candidateColumns } = useTableColumns()
+  const { searchContributorColumns, searchCandidateColumns } = useTableColumns()
 
   useEffect(() => {
     if (fetchInitialSearchData) {
@@ -45,11 +45,14 @@ const SearchResults = React.memo(() => {
     }
   }, [searchTerm, fetchInitialSearchData])
 
-  const handleCandidateSort = useCallback(
-    (sortBy) => {
+  const handleCandidateDataChange = useCallback(
+    ({ sortBy, filters }) => {
       const sort = formatSortBy(sortBy)
-      if (sort !== lastCandidatesQuery.sort) {
-        const query = { ...lastCandidatesQuery, sort }
+      if (
+        sort !== lastCandidatesQuery.sort ||
+        filters !== lastCandidatesQuery.filters
+      ) {
+        const query = { ...lastCandidatesQuery, sort, filters }
         setLastCandidatesQuery(query)
         fetchCandidates(query)
       }
@@ -57,11 +60,14 @@ const SearchResults = React.memo(() => {
     [fetchCandidates, lastCandidatesQuery]
   )
 
-  const handleContributorsSort = useCallback(
-    (sortBy) => {
+  const handleContributorDataChange = useCallback(
+    ({ sortBy, filters }) => {
       const sort = formatSortBy(sortBy)
-      if (sort !== lastContributorsQuery.sort) {
-        const query = { ...lastContributorsQuery, sort }
+      if (
+        sort !== lastContributorsQuery.sort ||
+        filters !== lastContributorsQuery.filters
+      ) {
+        const query = { ...lastContributorsQuery, sort, filters }
         setLastContributorsQuery(query)
         fetchContributors(query)
       }
@@ -148,7 +154,7 @@ const SearchResults = React.memo(() => {
         content: (
           <SearchResultTable
             apiStatus={candidateApiStatus}
-            columns={candidateColumns}
+            columns={searchCandidateColumns}
             data={candidates}
             count={candidateCount}
             offset={lastCandidatesQuery.offset}
@@ -157,7 +163,7 @@ const SearchResults = React.memo(() => {
             fetchPrevious={fetchPreviousCandidates}
             searchTerm={searchTerm}
             searchType="candidates"
-            onChangeSort={handleCandidateSort}
+            onFetchData={handleCandidateDataChange}
           />
         ),
         expanded: true,
@@ -168,7 +174,7 @@ const SearchResults = React.memo(() => {
         content: (
           <SearchResultTable
             apiStatus={contributorApiStatus}
-            columns={contributorColumns}
+            columns={searchContributorColumns}
             data={contributors}
             count={contributorCount}
             offset={lastContributorsQuery.offset}
@@ -177,7 +183,7 @@ const SearchResults = React.memo(() => {
             fetchPrevious={fetchPreviousContributors}
             searchTerm={searchTerm}
             searchType="contributors"
-            onChangeSort={handleContributorsSort}
+            onFetchData={handleContributorDataChange}
           />
         ),
         expanded: true,
@@ -186,11 +192,11 @@ const SearchResults = React.memo(() => {
     ],
     [
       candidateApiStatus,
-      candidateColumns,
+      searchCandidateColumns,
       candidates,
       candidateCount,
       contributorApiStatus,
-      contributorColumns,
+      searchContributorColumns,
       contributors,
       contributorCount,
       searchTerm,
@@ -202,8 +208,8 @@ const SearchResults = React.memo(() => {
       fetchSameContributors,
       fetchNextContributors,
       fetchPreviousContributors,
-      handleContributorsSort,
-      handleCandidateSort,
+      handleCandidateDataChange,
+      handleContributorDataChange,
     ]
   )
 

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -38,6 +38,7 @@ const SearchResults = React.memo(() => {
         searchTerm,
         offset: 0,
         limit: API_BATCH_SIZE,
+        filters: [],
       }
       setLastCandidatesQuery(query)
       setLastContributorsQuery(query)
@@ -50,7 +51,7 @@ const SearchResults = React.memo(() => {
       const sort = formatSortBy(sortBy)
       if (
         sort !== lastCandidatesQuery.sort ||
-        filters !== lastCandidatesQuery.filters
+        JSON.stringify(filters) !== JSON.stringify(lastCandidatesQuery.filters)
       ) {
         const query = { ...lastCandidatesQuery, sort, filters }
         setLastCandidatesQuery(query)
@@ -65,7 +66,8 @@ const SearchResults = React.memo(() => {
       const sort = formatSortBy(sortBy)
       if (
         sort !== lastContributorsQuery.sort ||
-        filters !== lastContributorsQuery.filters
+        JSON.stringify(filters) !==
+          JSON.stringify(lastContributorsQuery.filters)
       ) {
         const query = { ...lastContributorsQuery, sort, filters }
         setLastContributorsQuery(query)
@@ -164,6 +166,7 @@ const SearchResults = React.memo(() => {
             searchTerm={searchTerm}
             searchType="candidates"
             onFetchData={handleCandidateDataChange}
+            appliedFilters={lastCandidatesQuery.appliedFilters}
           />
         ),
         expanded: true,
@@ -184,6 +187,7 @@ const SearchResults = React.memo(() => {
             searchTerm={searchTerm}
             searchType="contributors"
             onFetchData={handleContributorDataChange}
+            appliedFilters={lastContributorsQuery.appliedFilters}
           />
         ),
         expanded: true,

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -125,6 +125,10 @@ ifream:focus, [href]:focus, [contentEditable="true"]:focus {
   text-align: center;
 }
 
+.extra-width {
+  max-width: 75rem;
+}
+
 /* SEARCH BAR */
 .search-bar .usa-button {
   background-color: #26A677;

--- a/src/hooks/useCandidate.js
+++ b/src/hooks/useCandidate.js
@@ -14,11 +14,17 @@ const constructContributionsUrl = ({
   limit,
   offset,
   sort,
+  filters,
 }) => {
   candidateId = encodeURIComponent(candidateId)
   let contributionsUrl = `${url}${candidateId}/contributions?limit=${limit}&offset=${offset}`
   if (sort) {
     contributionsUrl = `${contributionsUrl}&sortBy=${sort}`
+  }
+  if (filters.length) {
+    filters.forEach(({ id, value }) => {
+      contributionsUrl = `${contributionsUrl}&${id}=${value}`
+    })
   }
   return contributionsUrl
 }
@@ -62,13 +68,20 @@ export const useCandidate = () => {
   )
 
   const fetchContributions = useCallback(
-    async ({ candidateId, limit = API_BATCH_SIZE, offset = 0, sort } = {}) => {
+    async ({
+      candidateId,
+      limit = API_BATCH_SIZE,
+      offset = 0,
+      sort,
+      filters = [],
+    } = {}) => {
       const url = constructContributionsUrl({
         url: CANDIDATE_URL,
         candidateId,
         limit,
         offset,
         sort,
+        filters,
       })
       try {
         const { data, count, summary } = await getDataCountSummary(url)

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -7,10 +7,26 @@ import { useApi } from './useApi'
 const CONTRIBUTORS_URL = '/api/search/contributors/'
 const CANDIDATES_URL = '/api/search/candidates/'
 
-const constructSearchUrl = ({ url, searchTerm, limit, offset, sort }) => {
+const filterIdMap = {
+  candidate_full_name: 'name',
+}
+
+const constructSearchUrl = ({
+  url,
+  searchTerm,
+  limit,
+  offset,
+  sort,
+  filters,
+}) => {
   let searchUrl = `${url}${searchTerm}?limit=${limit}&offset=${offset}`
   if (sort) {
     searchUrl = `${searchUrl}&sortBy=${sort}`
+  }
+  if (filters.length) {
+    filters.forEach(({ id, value }) => {
+      searchUrl = `${searchUrl}&${filterIdMap[id] || id}=${value}`
+    })
   }
   return searchUrl
 }
@@ -27,13 +43,20 @@ export const useSearch = () => {
   )
 
   const fetchCandidates = useCallback(
-    async ({ searchTerm, limit = API_BATCH_SIZE, offset = 0, sort } = {}) => {
+    async ({
+      searchTerm,
+      limit = API_BATCH_SIZE,
+      offset = 0,
+      sort,
+      filters = [],
+    } = {}) => {
       const url = constructSearchUrl({
         url: CANDIDATES_URL,
         searchTerm,
         limit,
         offset,
         sort,
+        filters,
       })
       try {
         setCandidateApiStatus(STATUSES.Pending)
@@ -50,13 +73,20 @@ export const useSearch = () => {
   )
 
   const fetchContributors = useCallback(
-    async ({ searchTerm, limit = API_BATCH_SIZE, offset = 0, sort } = {}) => {
+    async ({
+      searchTerm,
+      limit = API_BATCH_SIZE,
+      offset = 0,
+      sort,
+      filters = [],
+    } = {}) => {
       const url = constructSearchUrl({
         url: CONTRIBUTORS_URL,
         searchTerm,
         limit,
         offset,
         sort,
+        filters,
       })
       try {
         setContributorApiStatus(STATUSES.Pending)

--- a/src/hooks/useTableColumns.js
+++ b/src/hooks/useTableColumns.js
@@ -1,14 +1,16 @@
 import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import InputFilter from '../components/InputFilter'
 
 const CANDIDATE_URL = '/candidate/'
 const CONTRIBUTOR_URL = '/contributors/'
 
 export const useTableColumns = () => {
-  const contributorColumns = useMemo(
+  const searchContributorColumns = useMemo(
     () => [
       {
         Header: 'Contributor Name',
+        id: 'name',
         accessor: ({ contributor_id, name }) => (
           <Link
             to={(location) => ({
@@ -20,31 +22,67 @@ export const useTableColumns = () => {
             {name}
           </Link>
         ),
+        disableSortBy: false,
+        disableFilters: false,
+        Filter: InputFilter,
       },
       {
         Header: 'City/State',
+        id: 'cityState',
         accessor: ({ city, state }) => city + ', ' + state,
-        disableSortBy: true,
+        disableFilters: false,
+        Filter: InputFilter,
       },
       {
         Header: 'Type',
         accessor: 'type',
-        disableSortBy: true,
       },
       {
         Header: 'Profession',
         accessor: 'profession',
-        disableSortBy: true,
+        disableFilters: false,
+        Filter: InputFilter,
       },
       {
         Header: 'Total Contributions',
         accessor: 'total',
-        disableSortBy: true,
       },
       {
         Header: 'Employer',
         accessor: 'employer_name',
-        disableSortBy: true,
+      },
+    ],
+    []
+  )
+
+  const searchCandidateColumns = useMemo(
+    () => [
+      {
+        Header: 'Name',
+        id: 'candidate_full_name',
+        accessor: ({ candidate_full_name, committee_sboe_id }) => (
+          <Link to={`${CANDIDATE_URL}${committee_sboe_id}`}>
+            &nbsp;
+            {candidate_full_name}
+          </Link>
+        ),
+        disableSortBy: false,
+        disableFilters: false,
+        Filter: InputFilter,
+      },
+      {
+        Header: 'Party',
+        accessor: 'party',
+        disableFilters: false,
+        Filter: InputFilter,
+      },
+      {
+        Header: 'Contest',
+        id: 'contest',
+        accessor: ({ office, juris }) =>
+          juris ? `${office} ${juris}` : office,
+        disableFilters: false,
+        Filter: InputFilter,
       },
     ],
     []
@@ -102,33 +140,6 @@ export const useTableColumns = () => {
     []
   )
 
-  const candidateColumns = useMemo(
-    () => [
-      {
-        Header: 'Name',
-        id: 'candidate_full_name',
-        accessor: ({ candidate_full_name, committee_sboe_id }) => (
-          <Link to={`${CANDIDATE_URL}${committee_sboe_id}`}>
-            &nbsp;
-            {candidate_full_name}
-          </Link>
-        ),
-      },
-      {
-        Header: 'Party',
-        accessor: 'party',
-        disableSortBy: true,
-      },
-      {
-        Header: 'Contest',
-        accessor: ({ office, juris }) =>
-          juris ? `${office} ${juris}` : office,
-        disableSortBy: true,
-      },
-    ],
-    []
-  )
-
   const candidateContributionColumns = useMemo(
     () => [
       {
@@ -137,11 +148,11 @@ export const useTableColumns = () => {
         accessor: ({ contributor_id, name }) => (
           <Link to={`${CONTRIBUTOR_URL}${contributor_id}`}>&nbsp;{name}</Link>
         ),
+        disableSortBy: false,
       },
       {
         Header: 'Transaction Type',
         accessor: 'transaction_type',
-        disableSortBy: true,
       },
       {
         id: 'amount',
@@ -153,11 +164,11 @@ export const useTableColumns = () => {
           })
           return formatter.format(r.amount)
         },
+        disableSortBy: false,
       },
       {
         Header: 'Form of Payment',
         accessor: 'form_of_payment',
-        disableSortBy: true,
       },
       {
         id: 'date_occurred',
@@ -170,19 +181,19 @@ export const useTableColumns = () => {
             day: '2-digit',
           })
         },
+        disableSortBy: false,
       },
       {
         Header: 'Comment',
         accessor: 'purpose',
-        disableSortBy: true,
       },
     ],
     []
   )
 
   return {
-    contributorColumns,
-    candidateColumns,
+    searchContributorColumns,
+    searchCandidateColumns,
     candidateContributionColumns,
     individualContributionsColumns,
   }


### PR DESCRIPTION
Add filtering for the tables on the Search Results page for all available filtering fields supported by the backend. Filters are text input fields with a 250ms debounce. See gif below for this feature in action.

Changes include:
- Convert onSortChange handling to generic data fetching
- Debounce filter and sort changes
- Rename columns variable name for search result page
- Remove existing component and types associated with old filtering
- Change defaultColumn to not enable filtering or sorting
- Add filters to api calls when they're provided
- Add new default Input filter component
- Add filtering to available columns on search results page
- Increase page content width on Search Results

![Kapture 2021-03-10 at 12 02 37](https://user-images.githubusercontent.com/39271238/110667759-933a0f80-8198-11eb-8084-2f88f7a7d8fa.gif)
