### PR TITLE
Add NULL delimiter to copyFromCSV

### DIFF
--- a/server/db/copyFromCSV.js
+++ b/server/db/copyFromCSV.js
@@ -12,7 +12,9 @@ const copyFromCSV = (path, tableName, client) =>
   new Promise((resolve, reject) => {
     const fileStream = fs.createReadStream(path)
     const stream = client.query(
-      copyFrom(`COPY ${tableName} FROM STDIN DELIMITER ',' csv HEADER`)
+      copyFrom(
+        `COPY ${tableName} FROM STDIN DELIMITER ',' csv HEADER NULL 'NULL'`
+      )
     )
     fileStream.on('error', (error) => {
       reject(error)


### PR DESCRIPTION
Add NULL delimiter to copyFromCSV. This tells postgres to treat the string `NULL` as the value `NULL` when doing the ETL. This fixes the problem with all the null fields in the data.

I have already tested these changes and uploaded a fresh dataset to prod. Now when searching you will not see a bunch of fields with the value `NULL`