### PR TITLE
feat: add download results button to expenditures table

### DIFF
--- a/server/api/expenditures.js
+++ b/server/api/expenditures.js
@@ -1,7 +1,10 @@
 const express = require('express')
 const db = require('../db')
-const { apiReprExpenditure, apiReprContribution } = require('../lib/repr')
-const { getExpenditures, getCommitteeContributions } = require('../lib/queries')
+const { apiReprExpenditure } = require('../lib/repr')
+const {
+  getExpenditures,
+  getExpendituresForDownload,
+} = require('../lib/queries')
 const { handleError, sendCSV } = require('../lib/helpers')
 
 const router = express()
@@ -9,19 +12,42 @@ const router = express()
 router.get('/expenditures/:ncsbeID', async (req, res) => {
   try {
     const { ncsbeID } = req.params
-    const { limit = 50, offset = 0, sortBy } = req.query
+    const { limit = 50, offset = 0, toCSV = false, sortBy } = req.query
 
-    const expenditures = await getExpenditures({
-      ncsbeID,
-      limit,
-      offset,
-      sortBy,
-    })
+    if (!toCSV) {
+      const expenditures = await getExpenditures({
+        ncsbeID,
+        limit,
+        offset,
+        sortBy,
+      })
 
-    res.send({
-      data: expenditures.rows.map(apiReprExpenditure),
-      count: expenditures.rows.length > 0 ? expenditures.rows[0].full_count : 0,
-    })
+      res.send({
+        data: expenditures.rows.map(apiReprExpenditure),
+        count:
+          expenditures.rows.length > 0 ? expenditures.rows[0].full_count : 0,
+      })
+    } else {
+      const [expenditures, candidate] = await Promise.all([
+        getExpendituresForDownload({
+          ncsbeID,
+        }),
+        getExpenditures(ncsbeID),
+      ])
+
+      if (expenditures.rows.length < 1 || !candidate) {
+        return handleError(
+          new Error(`no results found for candidate with id: ${ncsbeID}`),
+          res
+        )
+      }
+
+      sendCSV(
+        expenditures.rows.map(apiReprExpenditure),
+        `${ncsbeID}_expenditures.csv`,
+        res
+      )
+    }
   } catch (error) {
     handleError(error, res)
   }

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -376,6 +376,29 @@ const getCommitteeContributionsForDownload = ({ ncsbeID, client }) => {
 }
 
 /**
+ * Gets all expenditures for download
+ * @param {Object} args
+ * @param {string} args.ncsbeID
+ * @param {import('pg').PoolClient} args.client
+ * @returns {Promise<import('pg').QueryResult>}
+ */
+const getExpendituresForDownload = ({ ncsbeID, client }) => {
+  return db.query(
+    `select count(*) over () as full_count,
+    e.date_occurred,
+    e.form_of_payment,
+    e.transaction_type,
+    e.purpose,
+    e.amount,
+    v.name
+  from expenditures e join vendors v on e.contributor_id = v.account_id where (
+    lower(e.original_committee_sboe_id) = lower($1)
+  )`,
+    [ncsbeID]
+  )
+}
+
+/**
  *
  * @param {string} ncsbeID
  * @returns {Promise<Object|null>}
@@ -489,4 +512,5 @@ module.exports = {
   getCommittee,
   getCommitteeSummary,
   getExpenditures,
+  getExpendituresForDownload,
 }

--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -290,6 +290,8 @@ const Candidate = () => {
         </Grid>
         <Grid row></Grid>
         <br />
+        <br />
+        <br />
         <Grid row gap="sm">
           <Grid col={7} mobile={{ col: 6 }}>
             <p className="table-label">Expenditures</p>

--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -294,8 +294,7 @@ const Candidate = () => {
           <Grid col={7} mobile={{ col: 6 }}>
             <p className="table-label">Expenditures</p>
           </Grid>
-          {/* <Grid col={5} mobile={{ col: 6 }}>
-            <ReportError />
+          <Grid col={5} mobile={{ col: 6 }}>
             <a
               className="usa-button csv-download-button"
               href={`${
@@ -306,7 +305,7 @@ const Candidate = () => {
             >
               Download Results
             </a>
-          </Grid> */}
+          </Grid>
         </Grid>
         <Grid row>
           <Grid col>

--- a/src/components/Committee.js
+++ b/src/components/Committee.js
@@ -296,19 +296,18 @@ const Committee = () => {
           <Grid col={7} mobile={{ col: 6 }}>
             <p className="table-label">Expenditures</p>
           </Grid>
-          {/* <Grid col={5} mobile={{ col: 6 }}>
-            <ReportError />
+          <Grid col={5} mobile={{ col: 6 }}>
             <a
               className="usa-button csv-download-button"
               href={`${
                 process.env.NODE_ENV === 'production'
                   ? ''
                   : 'http://localhost:3001'
-              }/api/expenditures/${candidateId}?toCSV=true`}
+              }/api/expenditures/${committeeId}?toCSV=true`}
             >
               Download Results
             </a>
-          </Grid> */}
+          </Grid>
         </Grid>
         <Grid row>
           <Grid col>

--- a/src/components/Committee.js
+++ b/src/components/Committee.js
@@ -292,6 +292,8 @@ const Committee = () => {
         </Grid>
         <Grid row></Grid>
         <br />
+        <br />
+        <br />
         <Grid row gap="sm">
           <Grid col={7} mobile={{ col: 6 }}>
             <p className="table-label">Expenditures</p>


### PR DESCRIPTION
#281: I added the `Download Results` button to the expenditures table for both the `Candidate` and `Committee` pages. So feel free to test on a candidate and non-candidate page and see if it works for you.

<img width="1067" alt="Screen Shot 2021-06-08 at 7 44 31 PM" src="https://user-images.githubusercontent.com/16669854/121271559-f881c780-c891-11eb-878e-391aea78913b.png">
