### PR TITLE
fix: update data dictionary json to read links #191

### DIFF
--- a/src/components/DataDictionary.js
+++ b/src/components/DataDictionary.js
@@ -35,7 +35,10 @@ const DataDictionary = () => {
               .map(({ longVariableName: name, definition, source }) => (
                 <tr key={name}>
                   <th scope="row">{name}</th>
-                  <td style={{ maxWidth: '400px' }}>{definition}</td>
+                  <td
+                    style={{ minWidth: '200px' }}
+                    dangerouslySetInnerHTML={{ __html: definition }}
+                  ></td>
                   <td>{source}</td>
                 </tr>
               ))}

--- a/src/static/dataDictionary.json
+++ b/src/static/dataDictionary.json
@@ -1,17 +1,17 @@
 [
   {
     "longVariableName": "Amount",
-    "definition": "Value of a contribution in dollars. ",
+    "definition": "Value of a contribution in dollars.",
     "source": "\"Reported by committee to NC State Board of Elections on Form CRO-1210 Contributions from Individuals field k Amount, CRO 1220 Contributions from Political Party Committees field h Amount, or CRO 1230 Contributions from Other Political Committees field j Amount.\"\r"
   },
   {
     "longVariableName": "Candidate Name",
-    "definition": "\"Full name of candidate. \"\"[An individual who has filed either a notice of candidacy for public office or a petition requesting to be a candidate. It also refers to an individual who has been certified as a nominee of a political party for a vacancy or has qualified by an authorized means as a candidate. An individual is also considered a candidate if he or she has made a public announcement of a definite intent to run for public office in a particular election. An individual is also considered a candidate even if he or she has not met any of the above criteria, but has received funds, made payments, or consented for anyone else to receive funds or transfer anything of value for the purpose of bringing about that individual’s nomination or election to office.\"\" (Campaign Finance Manual version 12.19 https://s3.amazonaws.com/dl.ncsbe.gov/Campaign_Finance/Campaign%20Finance%20Manual%20Version%2012.19.pdf)\"",
+    "definition": "\"Full name of candidate. [An individual who has filed either a notice of candidacy for public office or a petition requesting to be a candidate. It also refers to an individual who has been certified as a nominee of a political party for a vacancy or has qualified by an authorized means as a candidate. An individual is also considered a candidate if he or she has made a public announcement of a definite intent to run for public office in a particular election. An individual is also considered a candidate even if he or she has not met any of the above criteria, but has received funds, made payments, or consented for anyone else to receive funds or transfer anything of value for the purpose of bringing about that individual’s nomination or election to office.\" (<a href='https://s3.amazonaws.com/dl.ncsbe.gov/Campaign_Finance/Campaign%20Finance%20Manual%20Version%2012.19.pdf' target='_blank'>Campaign Finance Manual version 12.19</a>).",
     "source": "Reported to NC State Board of Elections on CRO-2100A Statement of Organization - Candidate Committee Field 2a Full name\r"
   },
   {
     "longVariableName": "Contributor City",
-    "definition": "City of contributor's address",
+    "definition": "City of contributor's address.",
     "source": "\"Reported by committee to NC State Board of Elections in field 3a Contributor Information of Form CRO-1210 Contributions from Individuals,  CRO 1220 Contributions from Political Party Committees field b Comments, or CRO 1230 Contributions from Other Political Committees. \"\r"
   },
   {
@@ -21,12 +21,12 @@
   },
   {
     "longVariableName": "Contribution Date",
-    "definition": "Date on which the contribution was received by the committee",
+    "definition": "Date on which the contribution was received by the committee.",
     "source": "\"Reported by committee to NC State Board of Elections on Form CRO 1210 Contributions from Individuals field j Date, CRO 1220 Contributions from Political Party Committees field g Date, or CRO 1230 Contributions from Other Political Committees field i Date.\"\r"
   },
   {
     "longVariableName": "Employer Name or Specific Field",
-    "definition": "\"Name of contributor's employer. \"\"Committees must report the principal occupation of the contributor on the date the contribution is made. See N.C.G.S. § 163-278.11(a)(1). A committee fulfills this requirement by disclosing the contributor’s “job title or profession” and “employer’s name or employer’s specific field of business activity.” (Campaign Finance Manual version 12.19 https://s3.amazonaws.com/dl.ncsbe.gov/Campaign_Finance/Campaign%20Finance%20Manual%20Version%2012.19.pdf)\"",
+    "definition": "\"Name of contributor's employer. Committees must report the principal occupation of the contributor on the date the contribution is made. See N.C.G.S. § 163-278.11(a)(1). A committee fulfills this requirement by disclosing the contributor’s “job title or profession” and “employer’s name or employer’s specific field of business activity.”\" (<a href='https://s3.amazonaws.com/dl.ncsbe.gov/Campaign_Finance/Campaign%20Finance%20Manual%20Version%2012.19.pdf' target='_blank'>Campaign Finance Manual version 12.19</a>)",
     "source": "Reported by committee to NC State Board of Elections in Field 3c Employer's Name/Specific Field on Form CRO-1210 Contributions from Individuals. \r"
   },
   {
@@ -36,37 +36,37 @@
   },
   {
     "longVariableName": "Jurisdiction",
-    "definition": "Unit of government",
+    "definition": "Unit of government.",
     "source": "Reported to NC State Board of Elections on CRO-2100A Statement of Organization - Candidate Committee Field 2i Jurisdiction\r"
   },
   {
     "longVariableName": "Contributor Name",
-    "definition": "\"First and last name of individual, name of committee, or name of business\"",
+    "definition": "\"First and last name of individual, name of committee, or name of business.\"",
     "source": "\"Reported by committee to NC State Board of Elections in field 3a Contributor Information of Form CRO-1210 Contributions from Individuals,  CRO 1220 Contributions from Political Party Committees field b Comments, or CRO 1230 Contributions from Other Political Committees. \"\r"
   },
   {
     "longVariableName": "Office Sought",
-    "definition": "Public office sought by a candidate",
+    "definition": "Public office sought by a candidate.",
     "source": "Reported to NC State Board of Elections on CRO-2100A Statement of Organization - Candidate Committee Field 2g Office Sought.\r"
   },
   {
     "longVariableName": "Party",
-    "definition": "A political party organized and operating in North Carolina",
+    "definition": "A political party organized and operating in North Carolina.",
     "source": "Reported to NC State Board of Elections on CRO-2100A Statement of Organization - Candidate Committee Field 2f Party affiliation.\r"
   },
   {
     "longVariableName": "Profession or Job Title",
-    "definition": "\"Contributor's profession. \"\"Committees must report the principal occupation of the contributor on the date the contribution is made. See N.C.G.S. § 163-278.11(a)(1). A committee fulfills this requirement by disclosing the contributor’s “job title or profession” and “employer’s name or employer’s specific field of business activity.” (Campaign Finance Manual version 12.19 https://s3.amazonaws.com/dl.ncsbe.gov/Campaign_Finance/Campaign%20Finance%20Manual%20Version%2012.19.pdf)\"",
+    "definition": "\"Contributor's profession. \"\"Committees must report the principal occupation of the contributor on the date the contribution is made. See N.C.G.S. § 163-278.11(a)(1). A committee fulfills this requirement by disclosing the contributor’s “job title or profession” and “employer’s name or employer’s specific field of business activity.” (<a href='https://s3.amazonaws.com/dl.ncsbe.gov/Campaign_Finance/Campaign%20Finance%20Manual%20Version%2012.19.pdf' target='_blank'>Campaign Finance Manual version 12.19</a>)\"",
     "source": "Reported by committee to NC State Board of Elections in Field 3b Job title / Profession on Form CRO-1210 Contributions from Individuals \r"
   },
   {
     "longVariableName": "Comment",
     "definition": "Purpose of expenditure or comment made about contribution or other transaction.",
-    "source": "\"Reported by committee to NC State Board of Elections on Form  CRO-1210 Contributions from Individuals field d Comments, CRO 1220 Contributions from Political Party.  Committees field b Comments, or CRO 1230 Contributions from Other Political Committees field d Comments\"\r"
+    "source": "\"Reported by committee to NC State Board of Elections on Form  CRO-1210 Contributions from Individuals field d Comments, CRO 1220 Contributions from Political Party. Committees field b Comments, or CRO 1230 Contributions from Other Political Committees field d Comments\"\r"
   },
   {
     "longVariableName": "Contributor State",
-    "definition": "State of contributor's address",
+    "definition": "State of contributor's address.",
     "source": "\"Reported by committee to NC State Board of Elections in field 3a Contributor Information of Form CRO-1210 Contributions from Individuals,  CRO 1220 Contributions from Political Party Committees field b Comments, or CRO 1230 Contributions from Other Political Committees. \"\r"
   },
   {


### PR DESCRIPTION
Technically #191 has been resolved but added this change instead of making a new ticket.

I updated `definition` in `dataDictionary.json` and `DataDictionary.js` to render as html so we can get those links to work instead of being a string.

It caused some table issues so I had to set a `minWidth` on the `Definition` column.

Before:
<img width="1106" alt="Screen Shot 2021-07-08 at 8 50 39 PM" src="https://user-images.githubusercontent.com/16669854/125007526-5db20f80-e02e-11eb-8c41-5851d1f7b368.png">

After:
<img width="1014" alt="Screen Shot 2021-07-08 at 8 51 29 PM" src="https://user-images.githubusercontent.com/16669854/125007533-63a7f080-e02e-11eb-8427-c12cc2017709.png">

