### PR TITLE
fix: sort arrows not remaining fixed

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -82,27 +82,42 @@ export default function Table({
                     <img
                       src={SortDescending}
                       alt="Descending"
-                      style={{ verticalAlign: 'middle', marginLeft: '10px' }}
-                      height="20px"
-                      width="20px"
+                      style={{
+                        verticalAlign: 'middle',
+                        marginLeft: '2px',
+                        position: 'absolute',
+                        marginTop: '4px',
+                      }}
+                      height="18px"
+                      width="18px"
                     />
                   )}
                   {column.isSortedDesc === false && (
                     <img
                       src={SortAscending}
                       alt="Ascending"
-                      style={{ verticalAlign: 'middle', marginLeft: '10px' }}
-                      height="20px"
-                      width="20px"
+                      style={{
+                        verticalAlign: 'middle',
+                        marginLeft: '2px',
+                        position: 'absolute',
+                        marginTop: '4px',
+                      }}
+                      height="18px"
+                      width="18px"
                     />
                   )}
                   {column.canSort && column.isSortedDesc === undefined && (
                     <img
                       src={SortUnsorted}
                       alt="Unsorted"
-                      style={{ verticalAlign: 'middle', marginLeft: '10px' }}
-                      height="20px"
-                      width="20px"
+                      style={{
+                        verticalAlign: 'middle',
+                        marginLeft: '2px',
+                        position: 'absolute',
+                        marginTop: '4px',
+                      }}
+                      height="18px"
+                      width="18px"
                     />
                   )}
                 </div>


### PR DESCRIPTION
#289 
Adjusted the css for the sorting arrows so they don't jump around when you click them.

Before:
<img width="1015" alt="Screen Shot 2021-07-13 at 9 38 03 PM" src="https://user-images.githubusercontent.com/16669854/125546943-f5dbf68e-a81f-4480-8013-578a57cebff5.png">

After:
<img width="996" alt="Screen Shot 2021-07-13 at 9 38 11 PM" src="https://user-images.githubusercontent.com/16669854/125546953-e1f15c08-5004-4da4-a0c7-c018c7803f12.png">

## Help Needed Below

Even though I didn't really touch anything, I randomly get this error:
<img width="1083" alt="Screen Shot 2021-07-13 at 9 41 12 PM" src="https://user-images.githubusercontent.com/16669854/125547203-f3127d7b-7e65-48f2-aea9-0fe7c0c5a5c9.png">

How to reproduce:
1. Go to Roy's candidate page
2. Click through the filters and then it should appear

I went to another candidate's page and I didn't get the error. I also can't reproduce it on the live website, so not sure what is happening 🤷‍♀️ 
