### PR TITLE
feat: add pac name to candidate page

### DIFF
--- a/server/lib/repr.js
+++ b/server/lib/repr.js
@@ -7,6 +7,7 @@ const apiReprCandidate = (row) => {
     candidate_full_name: row.candidate_full_name,
     candidate_last_name: row.candidate_last_name,
     candidate_middle_name: row.candidate_middle_name,
+    committee_name: row.committee_name,
     current_status: row.current_status,
     juris: row.juris,
     office: row.office,

--- a/server/test/test-routes.js
+++ b/server/test/test-routes.js
@@ -60,6 +60,7 @@ const expectedCandidateKeys = [
   'candidate_full_name',
   'candidate_last_name',
   'candidate_middle_name',
+  'committee_name',
   'current_status',
   'juris',
   'office',

--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -181,6 +181,10 @@ const Candidate = () => {
               <span className="candidate-prop-label">Contest:</span>
               {candidate.office}
             </p>
+            <p className="candidate-prop">
+              <span className="candidate-prop-label">PAC:</span>
+              {candidate.committee_name}
+            </p>
           </Grid>
           <Grid col>
             <p className="summary-stat">

--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -181,10 +181,12 @@ const Candidate = () => {
               <span className="candidate-prop-label">Contest:</span>
               {candidate.office}
             </p>
-            <p className="candidate-prop">
-              <span className="candidate-prop-label">PAC:</span>
-              {candidate.committee_name}
-            </p>
+            {candidate.committee_name && (
+              <p className="candidate-prop">
+                <span className="candidate-prop-label">PAC:</span>
+                {candidate.committee_name}
+              </p>
+            )}
           </Grid>
           <Grid col>
             <p className="summary-stat">


### PR DESCRIPTION
Added the PAC name to the candidate page below `Contest`:
<img width="1058" alt="Screen Shot 2021-07-25 at 7 41 32 PM" src="https://user-images.githubusercontent.com/16669854/126917340-1f959b4a-3df3-4cd8-826e-ccc24fe808a7.png">

Also updated the candidate keys in the test file.

Resolves #245 