### PR TITLE
feat: add placeholder for empty table values

### DIFF
--- a/src/hooks/useTableColumns.js
+++ b/src/hooks/useTableColumns.js
@@ -36,11 +36,11 @@ export const useTableColumns = () => {
       },
       {
         Header: 'Type',
-        accessor: 'type',
+        accessor: ({ type }) => (type ? type : '—'),
       },
       {
         Header: 'Profession',
-        accessor: 'profession',
+        accessor: ({ profession }) => (profession ? profession : '—'),
         disableFilters: false,
         Filter: InputFilter,
       },
@@ -50,7 +50,7 @@ export const useTableColumns = () => {
       },
       {
         Header: 'Employer',
-        accessor: 'employer_name',
+        accessor: ({ employer_name }) => (employer_name ? employer_name : '—'),
       },
     ],
     []
@@ -112,7 +112,7 @@ export const useTableColumns = () => {
       },
       {
         Header: 'Party',
-        accessor: 'party',
+        accessor: ({ party }) => (party ? party : '—'),
         disableFilters: false,
         Filter: InputFilter,
       },
@@ -120,7 +120,7 @@ export const useTableColumns = () => {
         Header: 'Contest',
         id: 'contest',
         accessor: ({ office, juris }) =>
-          juris ? `${office} ${juris}` : office,
+          !office ? '—' : juris ? `${office} ${juris}` : office,
         disableFilters: false,
         Filter: InputFilter,
       },
@@ -223,7 +223,7 @@ export const useTableColumns = () => {
       },
       {
         Header: 'Profession',
-        accessor: 'profession',
+        accessor: ({ profession }) => (profession ? profession : '—'),
       },
       {
         Header: 'Transaction Type',
@@ -274,7 +274,7 @@ export const useTableColumns = () => {
       },
       {
         Header: 'Profession',
-        accessor: 'profession',
+        accessor: ({ profession }) => (profession ? profession : '—'),
       },
       {
         Header: 'Transaction Type',
@@ -327,7 +327,7 @@ export const useTableColumns = () => {
       },
       {
         Header: 'Purpose',
-        accessor: 'purpose',
+        accessor: ({ purpose }) => (purpose ? purpose : '—'),
       },
       {
         id: 'amount',


### PR DESCRIPTION
I updated tables to accommodate empty values for fields that could be empty like profession, employer, purpose, etc. I didn't do the columns that should have a value like name, location, total contributions, etc. Not sure if doing this in `useTableColumns.js` was the best way, but here we are. This should cover all tables on all pages.

Issue: #243 

![Screen Shot 2021-08-03 at 8 34 00 PM](https://user-images.githubusercontent.com/16669854/128103317-e4756e73-c161-4fe6-bc7a-a66c102f3d47.png)


