### PR TITLE
chore: fix spelling errors in pr markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Description of changes that were made, new systems or services that were added, 
 
 # Why?
 
-Description of why we made the changes. Ideally, user-centric description along with any errors that we were experienced before the fix was made.
+Description of why we made the changes. Ideally, user-centric description along with any errors that we experienced before the fix was made.
 
 ## GitHub Issue
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# What?
+# Description
 
 Description of changes that were made, new systems or services that were added, and how things were implemented.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
-# What did you do?
+# What?
 
-Description of changes that weere made, new systems or servicees that were added, and how things were implemented.
+Description of changes that were made, new systems or services that were added, and how things were implemented.
 
-# Why did you do it?
+# Why?
 
-Description of why we made the changes. Ideeally, user-centric description along with any errors that we were experiencing before the fix was made.
+Description of why we made the changes. Ideally, user-centric description along with any errors that we were experiencing before the fix was made.
 
 ## GitHub Issue
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Description of changes that were made, new systems or services that were added, 
 
 # Why?
 
-Description of why we made the changes. Ideally, user-centric description along with any errors that we were experiencing before the fix was made.
+Description of why we made the changes. Ideally, user-centric description along with any errors that we were experienced before the fix was made.
 
 ## GitHub Issue
 


### PR DESCRIPTION
# What?
I guess I was having trouble with the "e" key when I typed this up originally. Fixed those spelling errors. Also made the headers less _aggressive_ 😅. Good news: it works when you open a PR! 🥳 

# Why?
Because grammar

## GitHub Issue
—

# Testing Steps
—

# Before and After Screenshots (if applicable)
