### PR TITLE
Fixing a couple of search result bugs

### DIFF
--- a/src/components/SearchResultTable.js
+++ b/src/components/SearchResultTable.js
@@ -59,7 +59,7 @@ const SearchResultTable = React.memo(
         <>
           <Dropdown
             value={apiLimit}
-            onChange={(e) => onChangeLimit(e.currentTarget.value)}
+            onChange={(e) => onChangeLimit(parseInt(e.currentTarget.value))}
           >
             {tableLimits.map(({ label, value }) => (
               <option key={value} value={value}>

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -202,7 +202,7 @@ const SearchResults = React.memo(() => {
       const query = {
         ...lastContributorsQuery,
         limit,
-        offset: lastContributorsQuery.offset + limit,
+        offset: lastContributorsQuery.offset - limit,
       }
       setLastContributorsQuery(query)
       fetchContributors(query)


### PR DESCRIPTION
# Description

This PR fixes a couple of search result bugs.
1. Previous button on the search results table is not going back, it's going forward (https://github.com/ncopenpass/CampaignFinance/issues/230)
2. When the show limit is changed and the user moves to the next page, the results range is incorrect (I can make an issue if helpful!)

# Why?
To make the UI work as expected.

## GitHub Issue
https://github.com/ncopenpass/CampaignFinance/issues/230

# Testing Steps

- Search "johnson" (https://www.transpare-nc.org/search/johnson)
- Scroll down to Contributor results
- Change show limit to "Show 25"
- Click "Next" 
- The results range should be 26-50 but instead is 0251-2525

<img width="670" alt="Screen Shot 2021-10-19 at 10 39 37 PM" src="https://user-images.githubusercontent.com/18451357/138019449-f26b65b6-f1b5-4c0d-a9a3-10d9ef3def84.png">

# Before and After Screenshots (if applicable)
