### PR TITLE
Fix/bug 305

### DIFF
--- a/src/components/Candidate.js
+++ b/src/components/Candidate.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Grid, GridContainer } from '@trussworks/react-uswds'
+import { Button, Grid, GridContainer } from '@trussworks/react-uswds'
 import NumberFormat from 'react-number-format'
 
 import { useCandidate, useTableColumns, useExpenditures } from '../hooks'
@@ -159,7 +159,7 @@ const Candidate = () => {
   const fetchPrevious = useCallback(
     ({ limit = API_BATCH_SIZE, type } = {}) => {
       let { query, setQuery, fetchData } = getFunctionsAndQuery(type)
-      let offset = query.offset - limit < 0 ? 0 : query.offset - limit;
+      let offset = query.offset - limit < 0 ? 0 : query.offset - limit
       query = { ...query, limit, offset: offset }
       setQuery(query)
       fetchData(query)
@@ -286,14 +286,18 @@ const Candidate = () => {
           <Grid col={5} mobile={{ col: 6 }}>
             <ReportError />
             <a
-              className="usa-button csv-download-button"
               href={`${
                 process.env.NODE_ENV === 'production'
                   ? ''
                   : 'http://localhost:3001'
               }/api/candidate/${candidateId}/contributions?toCSV=true&date_occurred_gte=${datePickerStart}&date_occurred_lte=${datePickerEnd}`}
             >
-              Download Results
+              <Button
+                disabled={contributionCount === 0}
+                className="csv-download-button"
+              >
+                Download Results
+              </Button>
             </a>
           </Grid>
         </Grid>
@@ -325,14 +329,18 @@ const Candidate = () => {
           </Grid>
           <Grid col={5} mobile={{ col: 6 }}>
             <a
-              className="usa-button csv-download-button"
               href={`${
                 process.env.NODE_ENV === 'production'
                   ? ''
                   : 'http://localhost:3001'
               }/api/expenditures/${candidateId}?toCSV=true&date_occurred_gte=${datePickerStart}&date_occurred_lte=${datePickerEnd}`}
             >
-              Download Results
+              <Button
+                className="csv-download-button"
+                disabled={expenditureCount === 0}
+              >
+                Download Results
+              </Button>
             </a>
           </Grid>
         </Grid>

--- a/src/components/Committee.js
+++ b/src/components/Committee.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Grid, GridContainer } from '@trussworks/react-uswds'
+import { Button, Grid, GridContainer } from '@trussworks/react-uswds'
 import NumberFormat from 'react-number-format'
 
 import { useCommittee, useTableColumns, useExpenditures } from '../hooks'
@@ -281,14 +281,18 @@ const Committee = () => {
           <Grid col={5} mobile={{ col: 6 }}>
             <ReportError />
             <a
-              className="usa-button csv-download-button"
               href={`${
                 process.env.NODE_ENV === 'production'
                   ? ''
                   : 'http://localhost:3001'
               }/api/committee/${committeeId}/contributions?toCSV=true&date_occurred_gte=${datePickerStart}&date_occurred_lte=${datePickerEnd}`}
             >
-              Download Results
+              <Button
+                className="csv-download-button"
+                disabled={contributionCount === 0}
+              >
+                Download Results
+              </Button>
             </a>
           </Grid>
         </Grid>
@@ -320,14 +324,18 @@ const Committee = () => {
           </Grid>
           <Grid col={5} mobile={{ col: 6 }}>
             <a
-              className="usa-button csv-download-button"
               href={`${
                 process.env.NODE_ENV === 'production'
                   ? ''
                   : 'http://localhost:3001'
               }/api/expenditures/${committeeId}?toCSV=true&date_occurred_gte=${datePickerStart}&date_occurred_lte=${datePickerEnd}`}
             >
-              Download Results
+              <Button
+                className="csv-download-button"
+                disabled={expenditureCount === 0}
+              >
+                Download Results
+              </Button>
             </a>
           </Grid>
         </Grid>

--- a/src/components/Contributor.js
+++ b/src/components/Contributor.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
-import { Grid, GridContainer } from '@trussworks/react-uswds'
+import { Button, Grid, GridContainer } from '@trussworks/react-uswds'
 
 import { useContributors } from '../hooks/useContributors'
 import SearchResultTable from './SearchResultTable'
@@ -10,7 +10,6 @@ import ReportError from './ReportError'
 import DateRange from './DateRange'
 
 import '../css/candidate.scss'
-import NumberFormat from 'react-number-format'
 
 const Contributor = () => {
   let { contributorId } = useParams()
@@ -115,14 +114,18 @@ const Contributor = () => {
           <Grid col={5} mobile={{ col: 6 }}>
             <ReportError />
             <a
-              className="usa-button csv-download-button"
               href={`${
                 process.env.NODE_ENV === 'production'
                   ? ''
                   : 'http://localhost:3001'
               }/api/contributor/${contributorId}/contributions?toCSV=true&date_occurred_gte=${datePickerStart}&date_occurred_lte=${datePickerEnd}`}
             >
-              Download Results
+              <Button
+                className="csv-download-button"
+                disabled={contributionCount === 0}
+              >
+                Download Results
+              </Button>
             </a>
           </Grid>
         </Grid>

--- a/src/components/DateRange.js
+++ b/src/components/DateRange.js
@@ -98,7 +98,6 @@ function DateRange({
           },
           defaultValue: datePickerStart,
           name: 'event-date-start',
-          minDate: '2018-01-01',
         }}
         endDateHint="mm/dd/yyyy"
         endDateLabel="End date"
@@ -110,7 +109,6 @@ function DateRange({
           },
           defaultValue: datePickerEnd,
           name: 'event-date-end',
-          minDate: '2018-01-01',
         }}
       />
     )


### PR DESCRIPTION
# Description

Disable download results buttons when there are zero results. Update for expenditures and contributions tables. Update for all 3 page types.

# Why?

Clicking the download results button when there are 0 results was throwing an error

## GitHub Issue

Closes #305 

# Testing Steps

# Before and After Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/71611913/140983173-df2b887c-d9cd-4b92-9f2b-1807b38b9feb.png)
