### PR TITLE
Fixes Aggregated Individual Contribution miscalculation

### DIFF
--- a/server/lib/queries.ts
+++ b/server/lib/queries.ts
@@ -51,8 +51,7 @@ export const getCandidateSummary = async ({
       select count(*)    as aggregated_contributions_count,
              sum(amount) as aggregated_contributions_sum
       from contributions
-      where contributor_id IS NULl
-        and canon_committee_sboe_id = $1
+      where canon_committee_sboe_id = $1
   )
   select sum(amount),
          avg(amount),


### PR DESCRIPTION
# Description

Modifies the `getCandidateSummary` query to include all contributions where the `canon_committee_sboe_id` matches the candidate, regardless of whether contributor_id is `NULL` or not.

# Why?

Aggregated individual contributions were not always included in the summary data on the upper right of a candidate's summary page

## GitHub Issue
https://github.com/ncopenpass/CampaignFinance/issues/330

# Testing Steps
Checkout this branch and navigate to http://localhost:3000/candidate/STA-C0498N-C-002
Expect that Roy Cooper's `Total Number of Aggregated Contributions` and `Sum of Aggregated Contributions` are both greater than 0.

# Before and After Screenshots (if applicable)
### Note the values in these screenshots reflect a subset of the total transactions (i.e. the calculations are correct, but the numbers are not).
## Before 
![image](https://user-images.githubusercontent.com/14829777/194780581-86c27de8-c928-4e0e-8788-db5d5f76de58.png)

## After 
![image](https://user-images.githubusercontent.com/14829777/194780915-9217fd6e-3a81-4ae5-aa92-7e3eb6799ad0.png)
